### PR TITLE
fix: fix `CompactTextString` panics with nested Anys and private fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased]
 
+## [v1.4.3](https://github.com/cosmos/gogoproto/releases/tag/v1.4.2) - 2022-10-14
+
 ### Bug Fixes
 
+- [#24](https://github.com/cosmos/gogoproto/pull/24) Fix `CompactTextString` panics with nested Anys and private fields.
 - [#14](https://github.com/cosmos/gogoproto/pull/14) Fix `make regenerate`.
 
 ## [v1.4.2](https://github.com/cosmos/gogoproto/releases/tag/v1.4.2) - 2022-09-14

--- a/proto/text.go
+++ b/proto/text.go
@@ -267,6 +267,12 @@ func (tm *TextMarshaler) writeStruct(w *textWriter, sv reflect.Value) error {
 	sprops := GetProperties(st)
 	for i := 0; i < sv.NumField(); i++ {
 		fv := sv.Field(i)
+
+		// skip unexported fields
+		if !fv.CanSet() {
+			continue
+		}
+
 		props := sprops.Prop[i]
 		name := st.Field(i).Name
 
@@ -482,7 +488,7 @@ var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Properties) error {
 	v = reflect.Indirect(v)
 
-	// if cannot set value, then it is unexported - skip
+	// skip unexported fields
 	if !v.CanSet() {
 		return nil
 	}
@@ -556,7 +562,7 @@ func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Propert
 		// Other values are handled below.
 	}
 
-	// Uints are no interfaces
+	// Uints are not interfaces
 	if v.Kind() == reflect.Uint ||
 		v.Kind() == reflect.Uint8 ||
 		v.Kind() == reflect.Uint16 ||

--- a/proto/text.go
+++ b/proto/text.go
@@ -268,13 +268,13 @@ func (tm *TextMarshaler) writeStruct(w *textWriter, sv reflect.Value) error {
 	for i := 0; i < sv.NumField(); i++ {
 		fv := sv.Field(i)
 
-		// skip unexported fields
-		if !fv.CanSet() {
-			continue
-		}
-
 		props := sprops.Prop[i]
 		name := st.Field(i).Name
+
+		// skip unexported fields (i.e first letter is lowercase)
+		if name[0] != strings.ToUpper(name)[0] {
+			continue
+		}
 
 		if name == "XXX_NoUnkeyedLiteral" {
 			continue

--- a/proto/text.go
+++ b/proto/text.go
@@ -488,11 +488,6 @@ var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Properties) error {
 	v = reflect.Indirect(v)
 
-	// skip unexported fields
-	if !v.CanSet() {
-		return nil
-	}
-
 	if props != nil {
 		if len(props.CustomType) > 0 {
 			custom, ok := v.Interface().(Marshaler)

--- a/proto/text.go
+++ b/proto/text.go
@@ -482,6 +482,11 @@ var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Properties) error {
 	v = reflect.Indirect(v)
 
+	// if cannot set value, then it is unexported - skip
+	if !v.CanSet() {
+		return nil
+	}
+
 	if props != nil {
 		if len(props.CustomType) > 0 {
 			custom, ok := v.Interface().(Marshaler)
@@ -549,6 +554,16 @@ func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Propert
 			return err
 		}
 		// Other values are handled below.
+	}
+
+	// Uints are no interfaces
+	if v.Kind() == reflect.Uint ||
+		v.Kind() == reflect.Uint8 ||
+		v.Kind() == reflect.Uint16 ||
+		v.Kind() == reflect.Uint32 ||
+		v.Kind() == reflect.Uint64 {
+		_, err := fmt.Fprintf(w, "%d", v.Uint())
+		return err
 	}
 
 	// We don't attempt to serialise every possible value type; only those

--- a/proto/text.go
+++ b/proto/text.go
@@ -558,22 +558,9 @@ func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Propert
 		// Other values are handled below.
 	}
 
-	// Handle Uints
-	if k == reflect.Uint ||
-		k == reflect.Uint8 ||
-		k == reflect.Uint16 ||
-		k == reflect.Uint32 ||
-		k == reflect.Uint64 {
-		_, err := fmt.Fprintf(w, "%d", v.Uint())
-		return err
-	}
-
 	// We don't attempt to serialise every possible value type; only those
 	// that can occur in protocol buffers.
 	switch k {
-	case reflect.Bool:
-		_, err := fmt.Fprint(w, v.Bool())
-		return err
 	case reflect.Slice:
 		// Should only be a []byte; repeated fields are handled in writeStruct.
 		if err := writeString(w, string(v.Bytes())); err != nil {

--- a/proto/text_test.go
+++ b/proto/text_test.go
@@ -516,3 +516,28 @@ func TestRacyMarshal(t *testing.T) {
 		}()
 	}
 }
+
+func TestAny(t *testing.T) {
+	any := &pb.MyMessage{Count: proto.Int32(47), Name: proto.String("David")}
+	proto.SetExtension(any, pb.E_Ext_Text, proto.String("bar"))
+	b, err := proto.Marshal(any)
+	if err != nil {
+		panic(err)
+	}
+	m := &proto3pb.Message{
+		Name:        "David",
+		ResultCount: 47,
+		Anything:    &types.Any{TypeUrl: proto.MessageName(any), Value: b},
+	}
+
+	expected := `name: "David"
+	result_count: 47
+	anything: <
+	  type_url: "test_proto.MyMessage"
+	  value: "\302\006\003bar\010/\022\005David"
+	>`
+	got := proto.MarshalTextString(m)
+	if strings.EqualFold(expected, got) {
+		t.Errorf("got = %s, want %s", expected, got)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/10965.
Looking at the tests now. Using a `replace` in the Cosmos SDK resolves https://github.com/cosmos/cosmos-sdk/pull/10965 and https://github.com/cosmos/cosmos-sdk/pull/13838 (using the codegen String method)

We'll need to tag `1.4.3` after.