### PR TITLE
fix: Allow null package name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v1.4.5](https://github.com/cosmos/gogoproto/releases/tag/v1.4.5) - 2023-    02-20
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v1.4.5](https://github.com/cosmos/gogoproto/releases/tag/v1.4.5) - 2023-    02-20
+## [v1.4.5](https://github.com/cosmos/gogoproto/releases/tag/v1.4.5) - 2023-02-20
 
 ### Improvements
 

--- a/proto/merge.go
+++ b/proto/merge.go
@@ -82,9 +82,11 @@ func mergedFileDescriptors(debug bool) (*descriptorpb.FileDescriptorSet, error) 
 			return nil, err
 		}
 
-		err = CheckImportPath(*fd.Name, *fd.Package)
-		if err != nil {
-			checkImportErr = append(checkImportErr, err.Error())
+		if fd.Name != nil && fd.Package != nil {
+			err := CheckImportPath(*fd.Name, *fd.Package)
+			if err != nil {
+				checkImportErr = append(checkImportErr, err.Error())
+			}
 		}
 
 		// If it's not in the protoregistry file descriptors, add it.


### PR DESCRIPTION
When integrating with the SDK (https://github.com/cosmos/cosmos-sdk/pull/14886), I encountered a nil reference error. It turns out it was (again) calling `*fd.Package`.

In this PR, I switched to use the safe getters `fd.GetPackage()` and `fd.GetName()`, which don't panic and return empty strings when it's nil.