### PR TITLE
fix: get a diff only when not in debug

### DIFF
--- a/proto/merge.go
+++ b/proto/merge.go
@@ -100,7 +100,7 @@ func mergedFileDescriptors(debug bool) (*descriptorpb.FileDescriptorSet, error) 
 			// If there's a mismatch, we log a warning. If there was no
 			// mismatch, then we do nothing, and take the protoregistry file
 			// descriptor as the correct one.
-			if !protov2.Equal(protodesc.ToFileDescriptorProto(protoregFd), fd) {
+			if !protov2.Equal(protodesc.ToFileDescriptorProto(protoregFd), fd) && debug {
 				diff := cmp.Diff(protodesc.ToFileDescriptorProto(protoregFd), fd, protocmp.Transform())
 				diffErr = append(diffErr, fmt.Sprintf("Mismatch in %s:\n%s", *fd.Name, diff))
 			}


### PR DESCRIPTION
When running with `debug=false` calculating diffs make no sense given that they are not going to be printed. This was causing a lot of time being spent here for no reason