### PR TITLE
perf: reduce allocations in MergedFileDescriptors

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -614,7 +614,7 @@ func FileDescriptor(filename string) []byte { return protoFiles[filename] }
 // FileDescriptorProto.
 func AllFileDescriptors() map[string][]byte {
 	// we clone the map to prevent the caller from mutating it
-	cloned := map[string][]byte{}
+	cloned := make(map[string][]byte, len(protoFiles))
 	for file, bz := range protoFiles {
 		cloned[file] = bz
 	}


### PR DESCRIPTION
While profiling memory usage on the SDK's sim non-determinism test, MergedFileDescriptors showed up as a hotspot. By reusing a gzip.Reader and a bytes.Buffer instead of instantiating a new one on every loop, I was able to take the GC CPU fraction for that test (on a somewhat small case of 10 blocks of block size 10), from about 5.1% to about 2.6%, roughly cutting GC time in half. Also pre-size a couple slices that have an obvious final size.

In the real world, I don't think apps tend to have that many calls to NewInterfaceRegistry, but more efficient memory usage in that call certainly won't hurt.