### PR TITLE
Improve error message for bad timestamps

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -918,7 +918,7 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 
 			t, err := time.Parse(time.RFC3339Nano, unq)
 			if err != nil {
-				return fmt.Errorf("bad Timestamp: %v", err)
+				return fmt.Errorf("bad Timestamp, should be RFC 3339 encoded: %v", err)
 			}
 
 			target.Field(0).SetInt(t.Unix())


### PR DESCRIPTION
Its very painful to figure out how to correctly encode timestamps right now. This at least saves one step, so you know what to google