### PR TITLE
typo fix remap.go

### DIFF
--- a/protoc-gen-gogo/generator/internal/remap/remap.go
+++ b/protoc-gen-gogo/generator/internal/remap/remap.go
@@ -47,7 +47,7 @@ type Location struct {
 }
 
 // A Map represents a mapping between token locations in an input source text
-// and locations in the correspnding output text.
+// and locations in the corresponding output text.
 type Map map[Location]Location
 
 // Find reports whether the specified span is recorded by m, and if so returns


### PR DESCRIPTION
# Pull Request: Typo Fix in `remap.go`

## Description

This pull request fixes a typo in the `remap.go` file. The word **"correspnding"** was corrected to **"corresponding"**.

### Changes Made
- Corrected a typo:
  - Original: `correspnding`
  - Updated: `corresponding`

