### PR TITLE
Typo fix unmarshalmerge_test.go

### DIFF
--- a/test/unmarshalmerge/unmarshalmerge_test.go
+++ b/test/unmarshalmerge/unmarshalmerge_test.go
@@ -94,6 +94,6 @@ func TestInt64Merge(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !p.Equal(p2) {
-		t.Fatalf("exptected %#v but got %#v", p2, p)
+		t.Fatalf("expected %#v but got %#v", p2, p)
 	}
 }


### PR DESCRIPTION
Fixed a typo in unmarshalmerge_test.go by changing "exptected" to "expected."